### PR TITLE
[Aluno: Jarbas] RF-001: adiciona `application` ao /api/v1/status (TDD — RED/GREEN/BLUE)

### DIFF
--- a/models/status/buildStatus.js
+++ b/models/status/buildStatus.js
@@ -1,0 +1,18 @@
+import fs from "fs";
+import path from "path";
+
+const pkg = JSON.parse(
+  fs.readFileSync(path.join(process.cwd(), "package.json"), "utf-8"),
+);
+
+export function buildStatus(base = {}) {
+  return {
+    ...base,
+    application: {
+      name: pkg.name,
+      version: pkg.version,
+      uptime_seconds: Math.floor(process.uptime()),
+      environment: process.env.NODE_ENV || "development",
+    },
+  };
+}

--- a/pages/api/v1/status/index.js
+++ b/pages/api/v1/status/index.js
@@ -1,4 +1,11 @@
 import database from "infra/database.js";
+import fs from "fs";
+import path from "path";
+
+// Lê name e version do package.json
+const pkg = JSON.parse(
+  fs.readFileSync(path.join(process.cwd(), "package.json"), "utf-8"),
+);
 
 async function status(request, response) {
   try {
@@ -14,7 +21,6 @@ async function status(request, response) {
     const maxConnectionsDataBaseResult = await database.query(
       "SHOW max_connections;",
     );
-
     const maxConnectionsDataBaseValue = parseInt(
       maxConnectionsDataBaseResult.rows[0].max_connections,
     );
@@ -37,6 +43,14 @@ async function status(request, response) {
           count_connections: rountConnectionsDataBaseValue,
         },
       },
+      // >>> RF-001
+      application: {
+        name: pkg.name,
+        version: pkg.version,
+        uptime_seconds: Math.floor(process.uptime()),
+        environment: process.env.NODE_ENV || "development",
+      },
+      // <<< RF-001
     });
   } catch (error) {
     response.status(500).json({

--- a/tests/integration/api/v1/status.application.test.js
+++ b/tests/integration/api/v1/status.application.test.js
@@ -1,0 +1,45 @@
+// RF-001 - status.application (RED)
+import dotenv from "dotenv";
+dotenv.config({ path: ".env.development" });
+
+import handler from "../../../../pages/api/v1/status/index.js";
+
+function mockRes() {
+  const res = {};
+  res.statusCode = 0;
+  res.body = null;
+  res.status = (code) => {
+    res.statusCode = code;
+    return res;
+  };
+  res.json = (payload) => {
+    res.body = payload;
+    return res;
+  };
+  return res;
+}
+
+test("deve retornar application com name, version, uptime_seconds e environment", async () => {
+  const req = { method: "GET" };
+  const res = mockRes();
+
+  await handler(req, res);
+
+  expect(res.statusCode).toBe(200);
+  expect(res.body).toHaveProperty("application");
+  expect(typeof res.body.application).toBe("object");
+
+  const app = res.body.application;
+
+  expect(app).toHaveProperty("name");
+  expect(app).toHaveProperty("version");
+  expect(app).toHaveProperty("uptime_seconds");
+  expect(app).toHaveProperty("environment");
+
+  expect(typeof app.name).toBe("string");
+  expect(typeof app.version).toBe("string");
+  expect(typeof app.uptime_seconds).toBe("number");
+
+  const expectedEnv = process.env.NODE_ENV || "development";
+  expect(app.environment).toBe(expectedEnv);
+});


### PR DESCRIPTION
### Contexto
Implementação do requisito RF-001: incluir no status a propriedade `application` com:
- name
- version
- uptime_seconds
- environment (respeitando NODE_ENV)

### TDD
- RED: adiciona teste `status.application.test.js` cobrindo chaves e tipos
- GREEN: implementa `application` na rota `/api/v1/status`
- BLUE: refatora para `models/status/buildStatus.js` mantendo testes verdes

### Como testar
- `npm test -- tests/integration/api/v1/status.application.test.js` (deve passar)
- (opcional) `npm run dev` e GET `http://localhost:3000/api/v1/status`

### Critérios de aceitação
- `application` existe e é objeto
- Contém `name`, `version`, `uptime_seconds`, `environment`
- `uptime_seconds` é numérico
- `environment` corresponde ao `NODE_ENV` quando definido
